### PR TITLE
[PKG-2516] user-agents 2.2.0 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 upload_channels:
-  - sk_test
+  - sfe1ed40
 channels:
-  - sk_test
+  - sfe1ed40
 upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,24 @@
+{% set name = "user-agents" %}
 {% set version = "2.2.0" %}
 
 package:
-  name: user-agents
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/u/user-agents/user-agents-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d36d25178db65308d1458c5fa4ab39c9b2619377010130329f3955e7626ead26
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - ua-parser >=0.10.0
@@ -24,10 +26,11 @@ requirements:
 test:
   imports:
     - user_agents
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
+    - python -m unittest discover
 
 about:
   home: https://github.com/selwin/python-user-agents
@@ -35,7 +38,13 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: A library to identify devices (phones, tablets) and their capabilities by parsing (browser/HTTP) user agent strings
+  description: |
+    user_agents is a Python library that provides an easy way to identify/detect devices like mobile phones, tablets and their capabilities by parsing (browser/HTTP) user agent strings. The goal is to reliably detect whether:
+      - User agent is a mobile, tablet or PC based device.
+      - User agent has touch capabilities (has touch screen).
+    user_agents relies on the excellent ua-parser to do the actual parsing of the raw user agent string.
   dev_url: https://github.com/selwin/python-user-agents
+  doc_url: https://github.com/selwin/python-user-agents
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/selwin/python-user-agents/releases
License: https://github.com/selwin/python-user-agents/blob/v2.2.0/LICENSE.txt
Requirements: https://github.com/selwin/python-user-agents/blob/v2.2.0/setup.py

Actions:
1. Clean up the recipe:
- Add a jinja2 variable `name`
- Remove `noarch` python
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `setuptools` & `wheel` to `host`
2. Add `python -m unittest discover` to `test/commands`
3. Add `doc_url`
4. Add a `description`